### PR TITLE
Verification testing (#79)

### DIFF
--- a/.github/workflows/build-and-test-binary-on-pull-request.yml
+++ b/.github/workflows/build-and-test-binary-on-pull-request.yml
@@ -1,4 +1,4 @@
-name: Build on Pull Request
+name: Build and Test Binary on Pull Request
 
 # https://docs.github.com/en/actions/reference/events-that-trigger-workflows
 on:
@@ -7,7 +7,7 @@ on:
       - main
 
 jobs:
-  Build:
+  build_and_test:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -25,7 +25,7 @@ jobs:
 
     - name: Build
       run: go build -v ./...
-
+  
     # Run vet & lint on the code
     - name: Run vet & lint
       run: |

--- a/.github/workflows/build-and-test-docker-image-on-pull-request.yml
+++ b/.github/workflows/build-and-test-docker-image-on-pull-request.yml
@@ -1,16 +1,13 @@
-name: Build and test docker image on Pull and Push to main
+name: Build and Test Docker Image on Pull Request
 
 # https://docs.github.com/en/actions/reference/events-that-trigger-workflows
 on:
   pull_request:
     branches:
       - main
-  push:
-    branches:
-      - main
 
 jobs:
-  Build:
+  build_and_test:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -28,10 +25,19 @@ jobs:
         docker version
 
     # Build docker image
-    - name: Build & Run Docker Image
+    - name: Build Docker Image
       run: |
         docker build -t adscert-image .
-        docker run -d -p 3000:3000 --name aci-container adscert-image ./adscert signatory --private_key "Ys83NKuuYxCVDUbmA671x3zAFsQ-EnNxmC2JLuBlGAU" --origin "adscerttestsigner.dev"
+
+    # Run signer signatory
+    - name: Run Signer Signatory Container
+      run: |
+        docker run -d -p 3000:3000 --name signer-container adscert-image ./adscert signatory --private_key "Ys83NKuuYxCVDUbmA671x3zAFsQ-EnNxmC2JLuBlGAU" --origin "adscerttestsigner.dev"
+
+    # Run verifier signatory
+    - name: Run Verifier Signatory Container
+      run: |
+        docker run -d -p 4000:4000 --name verifier-container adscert-image ./adscert signatory --server_port 4000 --metrics_port 4001 --private_key "6mkLbsTBKs0UwYLkBdw5ttJHzjpSZxof0A2rako-0qs" --origin "adscerttestverifier.dev"
 
     # # Run integration tests against docker container
     - name: Run Docker Integration Tests

--- a/.github/workflows/build-test-and-release-binary-on-push.yml
+++ b/.github/workflows/build-test-and-release-binary-on-push.yml
@@ -1,4 +1,4 @@
-name: Build and Release on Push
+name: Build Test and Release Binary on Push
 
 # https://docs.github.com/en/actions/reference/events-that-trigger-workflows
 on:
@@ -7,7 +7,7 @@ on:
       - main
 
 jobs:
-  Build:
+  build_and_test:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -32,18 +32,11 @@ jobs:
         go vet ./...
         golint ./...
 
-    - name: Test
+    - name: Run Tests
       run: go test -v ./...
 
-    - name: Build and Push Docker Image
-      uses: mr-smithers-excellent/docker-build-push@v5
-      with:
-        image: adscert
-        registry: ghcr.io
-        username: ${{ secrets.GHCR_USERNAME }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-  Release:
+  release:
+    needs: build_and_test
     name: Create Release
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build-test-and-release-docker-image-on-push.yml
+++ b/.github/workflows/build-test-and-release-docker-image-on-push.yml
@@ -1,0 +1,62 @@
+name: Build Test and Release Docker Image on Push
+
+# https://docs.github.com/en/actions/reference/events-that-trigger-workflows
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build_and_test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.17
+
+    # Install all the dependencies
+    - name: Install dependencies
+      run: |
+        go version
+        go get -u golang.org/x/lint/golint
+        docker version
+
+    # Build docker image
+    - name: Build Docker Image
+      run: |
+        docker build -t adscert-image .
+
+    # Run signer signatory
+    - name: Run Signer Signatory Container
+      run: |
+        docker run -d -p 3000:3000 --name signer-container adscert-image ./adscert signatory --private_key "Ys83NKuuYxCVDUbmA671x3zAFsQ-EnNxmC2JLuBlGAU" --origin "adscerttestsigner.dev"
+
+    # Run verifier signatory
+    - name: Run Verifier Signatory Container
+      run: |
+        docker run -d -p 4000:4000 --name verifier-container adscert-image ./adscert signatory --server_port 4000 --metrics_port 4001 --private_key "6mkLbsTBKs0UwYLkBdw5ttJHzjpSZxof0A2rako-0qs" --origin "adscerttestverifier.dev"
+
+    # # Run integration tests against docker container
+    - name: Run Docker Integration Tests
+      run: |
+        cd cmd
+        go test -v . -tags integration 
+        
+  release:
+    needs: build_and_test
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Build and Release Docker Image
+      uses: mr-smithers-excellent/docker-build-push@v5
+      with:
+        image: adscert
+        registry: ghcr.io
+        username: ${{ secrets.GHCR_USERNAME }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+ 

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/IABTechLab/adscert/pkg/adscert/api"
 )
 
-//
 func TestSigningRequest(t *testing.T) {
 	testsignParams := &testsignParameters{}
 	testsignParams.url = "https://adscerttestverifier.dev"
@@ -24,6 +23,24 @@ func TestSigningRequest(t *testing.T) {
 		time.Sleep(5 * time.Second)
 		// succeeds on second run
 		if signRequest(testsignParams).GetSignatureOperationStatus() != api.SignatureOperationStatus_SIGNATURE_OPERATION_STATUS_OK {
+			t.Fail()
+		}
+	}
+}
+
+func TestVerificationRequest(t *testing.T) {
+	testverifyParams := &testverifyParameters{}
+	testverifyParams.destinationURL = "https://adscerttestverifier.dev"
+	testverifyParams.serverAddress = "localhost:4000"
+	testverifyParams.body = ""
+	testverifyParams.verifyingTimeout = 5 * time.Millisecond
+	testverifyParams.signatureMessage = "from=adscerttestsigner.dev&from_key=LxqTmA&invoking=adscerttestverifier.dev&nonce=jsLwC53YySqG&status=1&timestamp=220816T221250&to=adscerttestverifier.dev&to_key=uNzTFA; sigb=NfCC9zQeS3og&sigu=1tkmSdEe-5D7"
+	if verifyRequest(testverifyParams).GetVerificationInfo()[0].GetSignatureDecodeStatus()[0] != api.SignatureDecodeStatus_SIGNATURE_DECODE_STATUS_COUNTERPARTY_LOOKUP_ERROR {
+		t.Fail()
+	} else {
+		time.Sleep(5 * time.Second)
+		// succeeds on second run
+		if verifyRequest(testverifyParams).GetVerificationInfo()[0].GetSignatureDecodeStatus()[0] != api.SignatureDecodeStatus_SIGNATURE_DECODE_STATUS_BODY_AND_URL_VALID {
 			t.Fail()
 		}
 	}


### PR DESCRIPTION
* adds verification test integration testing

* fixes yml spacing

* switched timeout type

* test verify now returns verification

* ads server and metrics port flags for verifier signatory

* flag syntax

* updates signature message

* runs only verification

* adds second run of verification to allow for records to populate

* syntax

* tests signature decode status, expects counterparty lookup failure on the first run, success on the second

* syntax

* array access

* another array access

* syntax

* comments

* actions reorganization

* further action reorg

* adds action checkout

* releases require testing to pass